### PR TITLE
Initial hotseat Carcassone prototype

### DIFF
--- a/Data/GameDbContext.cs
+++ b/Data/GameDbContext.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+using KittyWorks.Carcassone.Models;
+
+namespace KittyWorks.Carcassone.Data;
+
+public class GameDbContext : DbContext
+{
+    public GameDbContext(DbContextOptions<GameDbContext> options) : base(options) { }
+
+    public DbSet<Game> Games => Set<Game>();
+}

--- a/KittyWorks.Carcassone.csproj
+++ b/KittyWorks.Carcassone.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/Models/Game.cs
+++ b/Models/Game.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KittyWorks.Carcassone.Models;
+
+public class Game
+{
+    [Key]
+    public int Id { get; set; }
+    public List<Player> Players { get; set; } = new();
+    public int CurrentPlayerIndex { get; set; }
+    public List<Tile> Deck { get; set; } = new();
+    public List<PlacedTile> PlacedTiles { get; set; } = new();
+}

--- a/Models/PlacedTile.cs
+++ b/Models/PlacedTile.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KittyWorks.Carcassone.Models;
+
+public class PlacedTile
+{
+    [Key]
+    public int Id { get; set; }
+    public TileType Type { get; set; }
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Rotation { get; set; }
+}

--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KittyWorks.Carcassone.Models;
+
+public class Player
+{
+    [Key]
+    public int Id { get; set; }
+    [Required]
+    public string Name { get; set; } = string.Empty;
+}

--- a/Models/Tile.cs
+++ b/Models/Tile.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace KittyWorks.Carcassone.Models;
+
+public class Tile
+{
+    [Key]
+    public int Id { get; set; }
+    public TileType Type { get; set; }
+}

--- a/Models/TileType.cs
+++ b/Models/TileType.cs
@@ -1,0 +1,8 @@
+namespace KittyWorks.Carcassone.Models;
+
+public enum TileType
+{
+    City,
+    Road,
+    Field
+}

--- a/Pages/Error.cshtml
+++ b/Pages/Error.cshtml
@@ -1,0 +1,26 @@
+﻿@page
+@model ErrorModel
+@{
+    ViewData["Title"] = "Error";
+}
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (Model.ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+    </p>
+}
+
+<h3>Development Mode</h3>
+<p>
+    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
+</p>
+<p>
+    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
+    It can result in displaying sensitive information from exceptions to end users.
+    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
+    and restarting the app.
+</p>

--- a/Pages/Error.cshtml.cs
+++ b/Pages/Error.cshtml.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace KittyWorks.Carcassone.Pages;
+
+[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+[IgnoreAntiforgeryToken]
+public class ErrorModel : PageModel
+{
+    public string? RequestId { get; set; }
+
+    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    private readonly ILogger<ErrorModel> _logger;
+
+    public ErrorModel(ILogger<ErrorModel> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OnGet()
+    {
+        RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+    }
+}
+

--- a/Pages/Game.cshtml
+++ b/Pages/Game.cshtml
@@ -1,0 +1,78 @@
+@page
+@model GameModel
+@{
+    ViewData["Title"] = "Game";
+    var game = Model.CurrentGame;
+}
+
+@if (game is null)
+{
+    <p>No game in progress.</p>
+}
+else
+{
+    <h2>Current Player: @game.Players[game.CurrentPlayerIndex].Name</h2>
+
+    @if (Model.NextTile != null)
+    {
+        <p>Next tile: @Model.NextTile.Type</p>
+        <form method="post" class="row g-3">
+            <div class="col-auto">
+                <label asp-for="X" class="form-label">X</label>
+                <input asp-for="X" class="form-control" />
+            </div>
+            <div class="col-auto">
+                <label asp-for="Y" class="form-label">Y</label>
+                <input asp-for="Y" class="form-control" />
+            </div>
+            <div class="col-auto">
+                <label asp-for="Rotation" class="form-label">Rotation</label>
+                <select asp-for="Rotation" class="form-select">
+                    <option value="0">0°</option>
+                    <option value="90">90°</option>
+                    <option value="180">180°</option>
+                    <option value="270">270°</option>
+                </select>
+            </div>
+            <div class="col-auto align-self-end">
+                <button type="submit" class="btn btn-primary mb-3">Place Tile</button>
+            </div>
+        </form>
+    }
+    else
+    {
+        <p>Deck empty. Game over.</p>
+    }
+
+    <h3>Board</h3>
+    @if (game.PlacedTiles.Any())
+    {
+        var minX = game.PlacedTiles.Min(t => t.X);
+        var maxX = game.PlacedTiles.Max(t => t.X);
+        var minY = game.PlacedTiles.Min(t => t.Y);
+        var maxY = game.PlacedTiles.Max(t => t.Y);
+        <table class="table table-bordered">
+        @for (var y = maxY; y >= minY; y--)
+        {
+            <tr>
+            @for (var x = minX; x <= maxX; x++)
+            {
+                var tile = game.PlacedTiles.FirstOrDefault(t => t.X == x && t.Y == y);
+                if (tile != null)
+                {
+                    <td>@tile.Type (@tile.Rotation)&deg;</td>
+                }
+                else
+                {
+                    <td>&nbsp;</td>
+                }
+            }
+            </tr>
+        }
+        </table>
+    }
+    else
+    {
+        <p>No tiles placed yet.</p>
+    }
+}

--- a/Pages/Game.cshtml.cs
+++ b/Pages/Game.cshtml.cs
@@ -1,0 +1,40 @@
+using KittyWorks.Carcassone.Models;
+using KittyWorks.Carcassone.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace KittyWorks.Carcassone.Pages;
+
+public class GameModel : PageModel
+{
+    private readonly GameService _gameService;
+
+    public GameModel(GameService gameService)
+    {
+        _gameService = gameService;
+    }
+
+    public Game? CurrentGame { get; set; }
+    public Tile? NextTile { get; set; }
+
+    [BindProperty]
+    public int X { get; set; }
+    [BindProperty]
+    public int Y { get; set; }
+    [BindProperty]
+    public int Rotation { get; set; }
+
+    public void OnGet()
+    {
+        CurrentGame = _gameService.GetGame();
+        NextTile = _gameService.NextTile(CurrentGame);
+    }
+
+    public IActionResult OnPost()
+    {
+        _gameService.PlaceTile(X, Y, Rotation);
+        CurrentGame = _gameService.GetGame();
+        NextTile = _gameService.NextTile(CurrentGame);
+        return Page();
+    }
+}

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -1,0 +1,24 @@
+@page
+@model IndexModel
+@{
+    ViewData["Title"] = "Home";
+}
+
+<h1>Carcassone Hotseat</h1>
+
+<form method="post" class="mt-3">
+    <div class="mb-3">
+        <label asp-for="Player1" class="form-label">Player 1</label>
+        <input asp-for="Player1" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Player2" class="form-label">Player 2</label>
+        <input asp-for="Player2" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Start Game</button>
+</form>
+
+@if (Model.HasGame)
+{
+    <a href="/Game" class="btn btn-secondary mt-3">Continue Current Game</a>
+}

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,0 +1,42 @@
+using KittyWorks.Carcassone.Services;
+using KittyWorks.Carcassone.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace KittyWorks.Carcassone.Pages;
+
+public class IndexModel : PageModel
+{
+    private readonly GameService _gameService;
+    private readonly GameDbContext _db;
+
+    public IndexModel(GameService gameService, GameDbContext db)
+    {
+        _gameService = gameService;
+        _db = db;
+    }
+
+    [BindProperty]
+    public string Player1 { get; set; } = string.Empty;
+    [BindProperty]
+    public string Player2 { get; set; } = string.Empty;
+
+    public bool HasGame { get; set; }
+
+    public void OnGet()
+    {
+        HasGame = _db.Games.Any();
+    }
+
+    public IActionResult OnPost()
+    {
+        if (string.IsNullOrWhiteSpace(Player1) || string.IsNullOrWhiteSpace(Player2))
+        {
+            ModelState.AddModelError(string.Empty, "Please enter player names.");
+            HasGame = _db.Games.Any();
+            return Page();
+        }
+        _gameService.CreateGame(Player1, Player2);
+        return RedirectToPage("/Game");
+    }
+}

--- a/Pages/Privacy.cshtml
+++ b/Pages/Privacy.cshtml
@@ -1,0 +1,8 @@
+﻿@page
+@model PrivacyModel
+@{
+    ViewData["Title"] = "Privacy Policy";
+}
+<h1>@ViewData["Title"]</h1>
+
+<p>Use this page to detail your site's privacy policy.</p>

--- a/Pages/Privacy.cshtml.cs
+++ b/Pages/Privacy.cshtml.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace KittyWorks.Carcassone.Pages;
+
+public class PrivacyModel : PageModel
+{
+    private readonly ILogger<PrivacyModel> _logger;
+
+    public PrivacyModel(ILogger<PrivacyModel> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OnGet()
+    {
+    }
+}
+

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,51 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - KittyWorks.Carcassone</title>
+    <script type="importmap"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/KittyWorks.Carcassone.styles.css" asp-append-version="true" />
+</head>
+<body>
+    <header>
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+            <div class="container">
+                <a class="navbar-brand" asp-area="" asp-page="/Index">KittyWorks.Carcassone</a>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
+                        aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                    <ul class="navbar-nav flex-grow-1">
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <div class="container">
+        <main role="main" class="pb-3">
+            @RenderBody()
+        </main>
+    </div>
+
+    <footer class="border-top footer text-muted">
+        <div class="container">
+            &copy; 2025 - KittyWorks.Carcassone - <a asp-area="" asp-page="/Privacy">Privacy</a>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/js/site.js" asp-append-version="true"></script>
+
+    @await RenderSectionAsync("Scripts", required: false)
+</body>
+</html>

--- a/Pages/Shared/_Layout.cshtml.css
+++ b/Pages/Shared/_Layout.cshtml.css
@@ -1,0 +1,48 @@
+﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
+for details on configuring this project to bundle and minify static web assets. */
+
+a.navbar-brand {
+  white-space: normal;
+  text-align: center;
+  word-break: break-all;
+}
+
+a {
+  color: #0077cc;
+}
+
+.btn-primary {
+  color: #fff;
+  background-color: #1b6ec2;
+  border-color: #1861ac;
+}
+
+.nav-pills .nav-link.active, .nav-pills .show > .nav-link {
+  color: #fff;
+  background-color: #1b6ec2;
+  border-color: #1861ac;
+}
+
+.border-top {
+  border-top: 1px solid #e5e5e5;
+}
+.border-bottom {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.box-shadow {
+  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
+}
+
+button.accept-policy {
+  font-size: 1rem;
+  line-height: inherit;
+}
+
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  white-space: nowrap;
+  line-height: 60px;
+}

--- a/Pages/_ViewImports.cshtml
+++ b/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+﻿@using KittyWorks.Carcassone
+@namespace KittyWorks.Carcassone.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/Pages/_ViewStart.cshtml
+++ b/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,33 @@
+using KittyWorks.Carcassone.Data;
+using KittyWorks.Carcassone.Services;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddRazorPages();
+builder.Services.AddDbContext<GameDbContext>(options =>
+    options.UseInMemoryDatabase("Carcassone"));
+builder.Services.AddScoped<GameService>();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapStaticAssets();
+app.MapRazorPages()
+   .WithStaticAssets();
+
+app.Run();

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5125",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7018;http://localhost:5125",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # KittyWorks.Carcassone
-Digital version of Carcassone board game ~vibing~
+
+Initial hotseat prototype of the board game **Carcassone** built with
+ASP.NET Core 9, Razor Pages, Bootstrap and vanilla JavaScript. Game
+state is stored using EF Core 9's in-memory provider.
+
+## Features
+
+- Two player hotseat play.
+- Each turn posts back to the server to place the next tile.
+- Very small tile set with minimal rule checking (adjacent placement).
+
+## Prerequisites
+
+- [.NET 9 SDK](https://dotnet.microsoft.com/).
+
+## Run
+
+```bash
+dotnet restore
+dotnet run
+```
+
+Then open `http://localhost:5000` (or the URL shown in the console) in a
+browser, enter two player names and start placing tiles.
+
+## Development Notes
+
+- Dependencies are managed with NuGet and pinned to stable releases (EF Core InMemory 9.0.8).
+- No favicon is included because binary assets are not stored in this repository.

--- a/Services/GameService.cs
+++ b/Services/GameService.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using KittyWorks.Carcassone.Data;
+using KittyWorks.Carcassone.Models;
+
+namespace KittyWorks.Carcassone.Services;
+
+public class GameService
+{
+    private readonly GameDbContext _db;
+    private static readonly Random _random = new();
+
+    public GameService(GameDbContext db)
+    {
+        _db = db;
+    }
+
+    public Game CreateGame(string player1, string player2)
+    {
+        _db.Games.RemoveRange(_db.Games);
+        var game = new Game
+        {
+            Players = new List<Player>
+            {
+                new() { Name = player1 },
+                new() { Name = player2 }
+            },
+            Deck = CreateDeck(),
+            CurrentPlayerIndex = 0
+        };
+        _db.Games.Add(game);
+        _db.SaveChanges();
+        return game;
+    }
+
+    private List<Tile> CreateDeck()
+    {
+        var tiles = new List<Tile>();
+        for (int i = 0; i < 20; i++)
+        {
+            tiles.Add(new Tile { Type = (TileType)_random.Next(0, 3) });
+        }
+        return tiles;
+    }
+
+    public Game? GetGame()
+    {
+        return _db.Games
+            .Include(g => g.Players)
+            .Include(g => g.Deck)
+            .Include(g => g.PlacedTiles)
+            .FirstOrDefault();
+    }
+
+    public Tile? NextTile(Game? game) => game?.Deck.FirstOrDefault();
+
+    public bool PlaceTile(int x, int y, int rotation)
+    {
+        var game = GetGame();
+        var next = NextTile(game);
+        if (game == null || next == null)
+            return false;
+        if (game.PlacedTiles.Any(t => t.X == x && t.Y == y))
+            return false;
+        if (game.PlacedTiles.Count > 0 &&
+            !game.PlacedTiles.Any(t => Math.Abs(t.X - x) + Math.Abs(t.Y - y) == 1))
+            return false;
+
+        game.PlacedTiles.Add(new PlacedTile
+        {
+            Type = next.Type,
+            X = x,
+            Y = y,
+            Rotation = rotation
+        });
+        game.Deck.RemoveAt(0);
+        game.CurrentPlayerIndex = (game.CurrentPlayerIndex + 1) % game.Players.Count;
+        _db.SaveChanges();
+        return true;
+    }
+}

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "DetailedErrors": true,
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1,0 +1,31 @@
+html {
+  font-size: 14px;
+}
+
+@media (min-width: 768px) {
+  html {
+    font-size: 16px;
+  }
+}
+
+.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
+  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
+}
+
+html {
+  position: relative;
+  min-height: 100%;
+}
+
+body {
+  margin-bottom: 60px;
+}
+
+.form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
+  color: var(--bs-secondary-color);
+  text-align: end;
+}
+
+.form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
+  text-align: start;
+}

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -1,0 +1,4 @@
+﻿// Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
+// for details on configuring this project to bundle and minify static web assets.
+
+// Write your JavaScript code.


### PR DESCRIPTION
## Summary
- scaffold ASP.NET Core 9 Razor Pages app
- add in-memory EF Core model and game service for tiles and turns
- implement two-player hotseat UI with bootstrap and server postbacks
- remove binary favicon asset and pin EF Core InMemory to stable release

## Testing
- `dotnet restore`
- `dotnet list package --outdated`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_68a62ea26648832580a1c0d80ab34ae1