### PR TITLE
Add basic tile graphics and scoring

### DIFF
--- a/Models/PieceType.cs
+++ b/Models/PieceType.cs
@@ -1,0 +1,7 @@
+namespace KittyWorks.Carcassone.Models;
+
+public enum PieceType
+{
+    Farmer,
+    Bishop
+}

--- a/Models/PlacedTile.cs
+++ b/Models/PlacedTile.cs
@@ -6,8 +6,11 @@ public class PlacedTile
 {
     [Key]
     public int Id { get; set; }
-    public TileType Type { get; set; }
+    public Tile Tile { get; set; } = new();
     public int X { get; set; }
     public int Y { get; set; }
     public int Rotation { get; set; }
+    public PieceType? Piece { get; set; }
+    public TileType? PieceFeature { get; set; }
+    public int? PiecePlayerIndex { get; set; }
 }

--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -8,4 +8,6 @@ public class Player
     public int Id { get; set; }
     [Required]
     public string Name { get; set; } = string.Empty;
+
+    public int Score { get; set; }
 }

--- a/Models/Tile.cs
+++ b/Models/Tile.cs
@@ -6,5 +6,6 @@ public class Tile
 {
     [Key]
     public int Id { get; set; }
-    public TileType Type { get; set; }
+    public TileType[] Edges { get; set; } = new TileType[4]; // N,E,S,W
+    public bool HasChurch { get; set; }
 }

--- a/Models/TileType.cs
+++ b/Models/TileType.cs
@@ -4,5 +4,6 @@ public enum TileType
 {
     City,
     Road,
-    Field
+    Field,
+    Church
 }

--- a/Pages/Game.cshtml
+++ b/Pages/Game.cshtml
@@ -11,32 +11,23 @@
 }
 else
 {
-    <h2>Current Player: @game.Players[game.CurrentPlayerIndex].Name</h2>
+    <div class="mb-3">
+        @foreach (var p in game.Players)
+        {
+            <span class="me-3"><strong>@p.Name</strong>: @p.Score</span>
+        }
+    </div>
 
     @if (Model.NextTile != null)
     {
-        <p>Next tile: @Model.NextTile.Type</p>
-        <form method="post" class="row g-3">
-            <div class="col-auto">
-                <label asp-for="X" class="form-label">X</label>
-                <input asp-for="X" class="form-control" />
-            </div>
-            <div class="col-auto">
-                <label asp-for="Y" class="form-label">Y</label>
-                <input asp-for="Y" class="form-control" />
-            </div>
-            <div class="col-auto">
-                <label asp-for="Rotation" class="form-label">Rotation</label>
-                <select asp-for="Rotation" class="form-select">
-                    <option value="0">0°</option>
-                    <option value="90">90°</option>
-                    <option value="180">180°</option>
-                    <option value="270">270°</option>
-                </select>
-            </div>
-            <div class="col-auto align-self-end">
-                <button type="submit" class="btn btn-primary mb-3">Place Tile</button>
-            </div>
+        <div class="mb-3">
+            <div class="tile tile-@Model.NextTile.Type.ToString().ToLower()" id="nextTile">@Model.NextTile.Type.ToString()[0]</div>
+            <button id="rotateBtn" class="btn btn-secondary btn-sm mt-2">Rotate</button>
+        </div>
+        <form method="post" id="placeForm">
+            <input type="hidden" asp-for="X" />
+            <input type="hidden" asp-for="Y" />
+            <input type="hidden" asp-for="Rotation" />
         </form>
     }
     else
@@ -44,35 +35,46 @@ else
         <p>Deck empty. Game over.</p>
     }
 
-    <h3>Board</h3>
-    @if (game.PlacedTiles.Any())
+    var minX = game.PlacedTiles.Any() ? game.PlacedTiles.Min(t => t.X) - 1 : -1;
+    var maxX = game.PlacedTiles.Any() ? game.PlacedTiles.Max(t => t.X) + 1 : 1;
+    var minY = game.PlacedTiles.Any() ? game.PlacedTiles.Min(t => t.Y) - 1 : -1;
+    var maxY = game.PlacedTiles.Any() ? game.PlacedTiles.Max(t => t.Y) + 1 : 1;
+    <table class="board">
+    @for (var y = maxY; y >= minY; y--)
     {
-        var minX = game.PlacedTiles.Min(t => t.X);
-        var maxX = game.PlacedTiles.Max(t => t.X);
-        var minY = game.PlacedTiles.Min(t => t.Y);
-        var maxY = game.PlacedTiles.Max(t => t.Y);
-        <table class="table table-bordered">
-        @for (var y = maxY; y >= minY; y--)
+        <tr>
+        @for (var x = minX; x <= maxX; x++)
         {
-            <tr>
-            @for (var x = minX; x <= maxX; x++)
-            {
-                var tile = game.PlacedTiles.FirstOrDefault(t => t.X == x && t.Y == y);
-                if (tile != null)
+            var tile = game.PlacedTiles.FirstOrDefault(t => t.X == x && t.Y == y);
+            <td class="board-cell @(tile == null ? "empty" : "")" data-x="@x" data-y="@y">
+                @if (tile != null)
                 {
-                    <td>@tile.Type (@tile.Rotation)&deg;</td>
+                    <div class="tile tile-@tile.Type.ToString().ToLower()" style="transform:rotate(@(tile.Rotation)deg)">@tile.Type.ToString()[0]</div>
                 }
-                else
-                {
-                    <td>&nbsp;</td>
-                }
-            }
-            </tr>
+            </td>
         }
-        </table>
+        </tr>
     }
-    else
-    {
-        <p>No tiles placed yet.</p>
-    }
+    </table>
+}
+
+@section Scripts {
+<script>
+let rotation = 0;
+const rotateBtn = document.getElementById('rotateBtn');
+rotateBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    rotation = (rotation + 90) % 360;
+    document.getElementById('Rotation').value = rotation;
+    document.getElementById('nextTile').style.transform = `rotate(${rotation}deg)`;
+});
+
+document.querySelectorAll('.board-cell.empty').forEach(cell => {
+    cell.addEventListener('click', () => {
+        document.getElementById('X').value = cell.dataset.x;
+        document.getElementById('Y').value = cell.dataset.y;
+        document.getElementById('placeForm').submit();
+    });
+});
+</script>
 }

--- a/Pages/Game.cshtml
+++ b/Pages/Game.cshtml
@@ -21,13 +21,37 @@ else
     @if (Model.NextTile != null)
     {
         <div class="mb-3">
-            <div class="tile tile-@Model.NextTile.Type.ToString().ToLower()" id="nextTile">@Model.NextTile.Type.ToString()[0]</div>
+            <div class="tile" id="nextTile">
+                @{ var dirs = new[]{"north","east","south","west"}; }
+                @for (int i = 0; i < 4; i++)
+                {
+                    <div class="edge @dirs[i] edge-@Model.NextTile.Edges[i].ToString().ToLower()"></div>
+                }
+                @if (Model.NextTile.HasChurch)
+                {
+                    <div class="edge center edge-church"></div>
+                }
+            </div>
             <button id="rotateBtn" class="btn btn-secondary btn-sm mt-2">Rotate</button>
         </div>
         <form method="post" id="placeForm">
             <input type="hidden" asp-for="X" />
             <input type="hidden" asp-for="Y" />
             <input type="hidden" asp-for="Rotation" />
+            <div class="mb-2">
+                <select asp-for="Piece" class="form-select form-select-sm mb-1">
+                    <option value="">No piece</option>
+                    <option value="Farmer">Farmer</option>
+                    <option value="Bishop">Bishop</option>
+                </select>
+                <select asp-for="Feature" class="form-select form-select-sm">
+                    <option value="">Feature</option>
+                    <option value="Road">Road</option>
+                    <option value="City">City</option>
+                    <option value="Field">Field</option>
+                    <option value="Church">Church</option>
+                </select>
+            </div>
         </form>
     }
     else
@@ -49,7 +73,21 @@ else
             <td class="board-cell @(tile == null ? "empty" : "")" data-x="@x" data-y="@y">
                 @if (tile != null)
                 {
-                    <div class="tile tile-@tile.Type.ToString().ToLower()" style="transform:rotate(@(tile.Rotation)deg)">@tile.Type.ToString()[0]</div>
+                    <div class="tile" style="transform:rotate(@(tile.Rotation)deg)">
+                        @{ var dirsPlaced = new[]{"north","east","south","west"}; }
+                        @for (int i = 0; i < 4; i++)
+                        {
+                            <div class="edge @dirsPlaced[i] edge-@tile.Tile.Edges[i].ToString().ToLower()"></div>
+                        }
+                        @if (tile.Tile.HasChurch)
+                        {
+                            <div class="edge center edge-church"></div>
+                        }
+                        @if (tile.Piece != null)
+                        {
+                            <div class="piece piece-@tile.Piece.ToString().ToLower()">@tile.Piece.ToString()[0]</div>
+                        }
+                    </div>
                 }
             </td>
         }

--- a/Pages/Game.cshtml.cs
+++ b/Pages/Game.cshtml.cs
@@ -23,6 +23,10 @@ public class GameModel : PageModel
     public int Y { get; set; }
     [BindProperty]
     public int Rotation { get; set; }
+    [BindProperty]
+    public PieceType? Piece { get; set; }
+    [BindProperty]
+    public TileType? Feature { get; set; }
 
     public void OnGet()
     {
@@ -32,7 +36,7 @@ public class GameModel : PageModel
 
     public IActionResult OnPost()
     {
-        _gameService.PlaceTile(X, Y, Rotation);
+        _gameService.PlaceTile(X, Y, Rotation, Piece, Feature);
         CurrentGame = _gameService.GetGame();
         NextTile = _gameService.NextTile(CurrentGame);
         return Page();

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -10,38 +10,11 @@
     <link rel="stylesheet" href="~/KittyWorks.Carcassone.styles.css" asp-append-version="true" />
 </head>
 <body>
-    <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
-            <div class="container">
-                <a class="navbar-brand" asp-area="" asp-page="/Index">KittyWorks.Carcassone</a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
-                        aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
-                    <ul class="navbar-nav flex-grow-1">
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        </nav>
-    </header>
     <div class="container">
         <main role="main" class="pb-3">
             @RenderBody()
         </main>
     </div>
-
-    <footer class="border-top footer text-muted">
-        <div class="container">
-            &copy; 2025 - KittyWorks.Carcassone - <a asp-area="" asp-page="/Privacy">Privacy</a>
-        </div>
-    </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>

--- a/Services/GameService.cs
+++ b/Services/GameService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using KittyWorks.Carcassone.Data;
 using KittyWorks.Carcassone.Models;
+using System.Linq;
 
 namespace KittyWorks.Carcassone.Services;
 
@@ -37,7 +38,13 @@ public class GameService
         var tiles = new List<Tile>();
         for (int i = 0; i < 20; i++)
         {
-            tiles.Add(new Tile { Type = (TileType)_random.Next(0, 4) });
+            var tile = new Tile();
+            for (int e = 0; e < 4; e++)
+            {
+                tile.Edges[e] = (TileType)_random.Next(0, 3); // city, road, field
+            }
+            tile.HasChurch = _random.Next(0, 5) == 0; // occasional church
+            tiles.Add(tile);
         }
         return tiles;
     }
@@ -53,7 +60,7 @@ public class GameService
 
     public Tile? NextTile(Game? game) => game?.Deck.FirstOrDefault();
 
-    public bool PlaceTile(int x, int y, int rotation)
+    public bool PlaceTile(int x, int y, int rotation, PieceType? piece, TileType? feature)
     {
         var game = GetGame();
         var next = NextTile(game);
@@ -61,29 +68,140 @@ public class GameService
             return false;
         if (game.PlacedTiles.Any(t => t.X == x && t.Y == y))
             return false;
-        if (game.PlacedTiles.Count > 0 &&
-            !game.PlacedTiles.Any(t => Math.Abs(t.X - x) + Math.Abs(t.Y - y) == 1))
+        bool hasAdjacent = game.PlacedTiles.Count == 0;
+        for (int dir = 0; dir < 4; dir++)
+        {
+            var (nx, ny) = Neighbor(x, y, dir);
+            var neighbor = game.PlacedTiles.FirstOrDefault(t => t.X == nx && t.Y == ny);
+            var edge = GetEdge(next, rotation, dir);
+            if (neighbor != null)
+            {
+                hasAdjacent = true;
+                var opposite = GetEdge(neighbor, (dir + 2) % 4);
+                if (edge != opposite)
+                    return false;
+            }
+        }
+        if (!hasAdjacent)
             return false;
 
-        game.PlacedTiles.Add(new PlacedTile
+        var placed = new PlacedTile
         {
-            Type = next.Type,
+            Tile = next,
             X = x,
             Y = y,
             Rotation = rotation
-        });
+        };
+
+        if (piece != null && feature != null && ValidPiecePlacement(next, piece.Value, feature.Value))
+        {
+            placed.Piece = piece;
+            placed.PieceFeature = feature;
+            placed.PiecePlayerIndex = game.CurrentPlayerIndex;
+        }
+
+        game.PlacedTiles.Add(placed);
         game.Deck.RemoveAt(0);
 
-        var currentPlayer = game.Players[game.CurrentPlayerIndex];
-        currentPlayer.Score += next.Type switch
-        {
-            TileType.City => 2,
-            TileType.Road => 2,
-            _ => 1
-        };
+        ResolveCompletions(game, placed);
 
         game.CurrentPlayerIndex = (game.CurrentPlayerIndex + 1) % game.Players.Count;
         _db.SaveChanges();
         return true;
+    }
+
+    private static TileType GetEdge(Tile tile, int rotation, int dir)
+    {
+        int index = (dir - rotation / 90 + 4) % 4;
+        return tile.Edges[index];
+    }
+
+    private static TileType GetEdge(PlacedTile tile, int dir)
+    {
+        int index = (dir - tile.Rotation / 90 + 4) % 4;
+        return tile.Tile.Edges[index];
+    }
+
+    private static (int x, int y) Neighbor(int x, int y, int dir) => dir switch
+    {
+        0 => (x, y + 1),
+        1 => (x + 1, y),
+        2 => (x, y - 1),
+        3 => (x - 1, y),
+        _ => (x, y)
+    };
+
+    private bool ValidPiecePlacement(Tile tile, PieceType piece, TileType feature)
+    {
+        if (piece == PieceType.Farmer && feature == TileType.Field)
+            return false;
+        if (piece == PieceType.Bishop && feature == TileType.Road)
+            return false;
+        if (feature == TileType.Church)
+            return tile.HasChurch;
+        return tile.Edges.Contains(feature);
+    }
+
+    private void ResolveCompletions(Game game, PlacedTile placed)
+    {
+        var visited = new HashSet<(int, int, int)>();
+        for (int dir = 0; dir < 4; dir++)
+        {
+            var feature = GetEdge(placed, dir);
+            if (feature != TileType.Road && feature != TileType.City)
+                continue;
+            if (visited.Contains((placed.X, placed.Y, dir)))
+                continue;
+            var region = new HashSet<PlacedTile>();
+            if (ExploreFeature(game, placed, dir, feature, visited, region))
+            {
+                int points = feature == TileType.Road ? region.Count : region.Count * 2;
+                foreach (var t in region)
+                {
+                    if (t.PieceFeature == feature && t.PiecePlayerIndex.HasValue)
+                    {
+                        game.Players[t.PiecePlayerIndex.Value].Score += points;
+                        t.Piece = null;
+                        t.PieceFeature = null;
+                        t.PiecePlayerIndex = null;
+                    }
+                }
+            }
+        }
+    }
+
+    private bool ExploreFeature(Game game, PlacedTile start, int startDir, TileType feature,
+        HashSet<(int, int, int)> visited, HashSet<PlacedTile> region)
+    {
+        var queue = new Queue<(PlacedTile tile, int dir)>();
+        queue.Enqueue((start, startDir));
+        bool closed = true;
+        while (queue.Count > 0)
+        {
+            var (tile, dir) = queue.Dequeue();
+            if (!visited.Add((tile.X, tile.Y, dir)))
+                continue;
+            region.Add(tile);
+            var (nx, ny) = Neighbor(tile.X, tile.Y, dir);
+            var neighbor = game.PlacedTiles.FirstOrDefault(t => t.X == nx && t.Y == ny);
+            if (neighbor == null)
+            {
+                closed = false;
+                continue;
+            }
+            int opposite = (dir + 2) % 4;
+            if (GetEdge(neighbor, opposite) != feature)
+            {
+                closed = false;
+                continue;
+            }
+            for (int i = 0; i < 4; i++)
+            {
+                if (i == opposite) continue;
+                if (GetEdge(neighbor, i) == feature)
+                    queue.Enqueue((neighbor, i));
+            }
+        }
+        return closed;
     }
 }

--- a/Services/GameService.cs
+++ b/Services/GameService.cs
@@ -37,7 +37,7 @@ public class GameService
         var tiles = new List<Tile>();
         for (int i = 0; i < 20; i++)
         {
-            tiles.Add(new Tile { Type = (TileType)_random.Next(0, 3) });
+            tiles.Add(new Tile { Type = (TileType)_random.Next(0, 4) });
         }
         return tiles;
     }
@@ -73,6 +73,15 @@ public class GameService
             Rotation = rotation
         });
         game.Deck.RemoveAt(0);
+
+        var currentPlayer = game.Players[game.CurrentPlayerIndex];
+        currentPlayer.Score += next.Type switch
+        {
+            TileType.City => 2,
+            TileType.Road => 2,
+            _ => 1
+        };
+
         game.CurrentPlayerIndex = (game.CurrentPlayerIndex + 1) % game.Players.Count;
         _db.SaveChanges();
         return true;

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -44,25 +44,83 @@ body {
 .tile {
   width: 50px;
   height: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #fff;
-  font-weight: bold;
+  position: relative;
 }
 
-.tile-city {
-  background-color: #f9c74f;
+.edge {
+  position: absolute;
 }
 
-.tile-road {
+.edge.north {
+  top: 0;
+  left: 10%;
+  width: 80%;
+  height: 15%;
+}
+
+.edge.south {
+  bottom: 0;
+  left: 10%;
+  width: 80%;
+  height: 15%;
+}
+
+.edge.east {
+  right: 0;
+  top: 10%;
+  width: 15%;
+  height: 80%;
+}
+
+.edge.west {
+  left: 0;
+  top: 10%;
+  width: 15%;
+  height: 80%;
+}
+
+.edge.center {
+  top: 25%;
+  left: 25%;
+  width: 50%;
+  height: 50%;
+}
+
+.edge-road {
   background-color: #90be6d;
 }
 
-.tile-field {
+.edge-city {
+  background-color: #f9c74f;
+}
+
+.edge-field {
   background-color: #f94144;
 }
 
-.tile-church {
+.edge-church {
   background-color: #577590;
+}
+
+.piece {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  background: #fff;
+  color: #000;
+}
+
+.piece-farmer {
+  background: #8bc34a;
+}
+
+.piece-bishop {
+  background: #ffc107;
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -29,3 +29,40 @@ body {
 .form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
   text-align: start;
 }
+
+.board {
+  border-collapse: collapse;
+}
+
+.board-cell {
+  width: 50px;
+  height: 50px;
+  padding: 0;
+  border: 1px solid #999;
+}
+
+.tile {
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: bold;
+}
+
+.tile-city {
+  background-color: #f9c74f;
+}
+
+.tile-road {
+  background-color: #90be6d;
+}
+
+.tile-field {
+  background-color: #f94144;
+}
+
+.tile-church {
+  background-color: #577590;
+}


### PR DESCRIPTION
## Summary
- Replace navigation layout with minimalist game-only view
- Render tiles graphically with clickable board and rotation support
- Track simple player scores with new tile type
- Fix tile rotation reference to ensure placed tiles render correctly

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_68a6ea50198083258afab3614e3390f1